### PR TITLE
Add portal around content of app bar icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,12 @@ typings/
 .vscode/
 
 package-lock.json
-frontend/config.json
+.DS_Store
+build
+.idea/
+npm-debug.log
+extension/coverage
+extension/node_modules
 extension/config.json
+frontend/config.json
+config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.1] - 2019-09-06
+## 1.1.0 - 2026-02-27
+### Added
+- Portal around content of the App Bar Icon: `ext-add-browse-appbar-ios.app_bar_icon`
+
+## 1.0.1 - 2019-09-06
 
 ### Fixed
 
 - The AppBar Logo on the Startpage doesn't jump anymore when the BurgerIcon is rendered.
 
-## [1.0.0] - 2019-09-03
+## 1.0.0 - 2019-09-03
 
 ### Added
 

--- a/frontend/components/BurgerIcon/index.jsx
+++ b/frontend/components/BurgerIcon/index.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import Button from '@shopgate/pwa-common/components/Button';
 import BurgerIcon from '@shopgate/pwa-ui-shared/icons/BurgerIcon';
 import Ripple from '@shopgate/pwa-ui-shared/Ripple';
-import { BROWSE_PATH } from '../../constants';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
+import { BROWSE_PATH, PORTAL_BURGER_ICON_CONTENT } from '../../constants';
 import styles from './style';
 import connect from './connector';
 import CustomBurgerIcon from '../CustomBurgerIcon';
@@ -51,12 +52,14 @@ class Burger extends Component {
         className={this.props.isHome ? styles.buttonHome : styles.button}
         aria-label={i18n.text('add_browse_appbar_ios.button_label')}
       >
-        <Ripple
-          className={styles.buttonContent}
-          onComplete={this.handleClick}
-        >
-          {BurgerSvg ? <CustomBurgerIcon className={styles.customBurgerIcon} /> : <BurgerIcon />}
-        </Ripple>
+        <SurroundPortals portalName={PORTAL_BURGER_ICON_CONTENT}>
+          <Ripple
+            className={styles.buttonContent}
+            onComplete={this.handleClick}
+          >
+            {BurgerSvg ? <CustomBurgerIcon className={styles.customBurgerIcon} /> : <BurgerIcon />}
+          </Ripple>
+        </SurroundPortals>
       </Button>
     );
   }

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -4,3 +4,5 @@ export const BROWSE_PATH = '/browse';
 export const burgerIconBlacklist = [
   BROWSE_PATH,
 ];
+
+export const PORTAL_BURGER_ICON_CONTENT = 'ext-add-browse-appbar-ios.app_bar_icon';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,43 +4,22 @@
   "description": "Will render a Burger Icon with browse function on the right side of the App Bar of the iOS theme.",
   "license": "Apache-2.0",
   "scripts": {
-    "lint": "eslint --parser babel-eslint --ignore-path ../.gitignore --ignore-path .eslintignore --ext .js --ext .jsx .",
-    "test": "jest",
-    "test:watch": "npm run test -- --watch",
-    "coverage": "jest --coverage",
-    "coverage:watch": "npm run coverage -- --watch"
+    "lint": "eslint --parser babel-eslint --ignore-path ../.gitignore --ignore-path .eslintignore --ext .js --ext .jsx ."
   },
   "devDependencies": {
-    "@shopgate/eslint-config": "^6.5.0",
-    "@shopgate/pwa-common": "^6.5.0",
-    "@shopgate/pwa-common-commerce": "^6.5.0",
-    "@shopgate/pwa-core": "^6.5.0",
-    "jest": "^22.4.2",
-    "@shopgate/pwa-unit-test": "^6.5.0",
-    "@shopgate/pwa-ui-ios": "^6.5.0",
-    "@shopgate/pwa-ui-shared": "^6.5.0",
-    "babel-core": "^6.26.0",
-    "babel-plugin-react-transform": "^3.0.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-inline-elements": "^6.22.0",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
-    "eslint": "^4.19.1",
-    "glamor": "^2.20.40",
-    "prop-types": "^15.6.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-helmet": "^5.2.0",
-    "react-transition-group": "^2.2.1",
-    "react-hot-loader": "^3.1.3",
-    "react-transform-catch-errors": "^1.0.2"
-  },
-  "peerDependenciees": {
-    "@shopgate/pwa-common": "^6.5.0",
-    "@shopgate/pwa-core": "^6.5.0"
+    "@shopgate/engage": "^7.30.0",
+    "@shopgate/eslint-config": "^7.30.0",
+    "@shopgate/pwa-common": "^7.30.0",
+    "@shopgate/pwa-common-commerce": "^7.30.0",
+    "@shopgate/pwa-core": "^7.30.0",
+    "@shopgate/pwa-unit-test": "^7.30.0",
+    "@shopgate/pwa-ui-ios": "^7.30.0",
+    "@shopgate/pwa-ui-shared": "^7.30.0",
+    "eslint": "^8.57.1",
+    "prop-types": "~15.8.1",
+    "react": "^17.0.2",
+    "react-redux": "^8.1.3",
+    "reselect": "^4.1.8"
   },
   "dependencies": {
     "@shopgate-ps/pwa-extension-kit": "^0.7.1"


### PR DESCRIPTION
This pull requests wraps the content of the app bar icon with a portal that can be used to add e.g. badges to the icon.