### PR TITLE
Hide app bar icon on CMS page preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.0 - 2026-04-14
+### Added
+- App bar icon is hidden in CMS page preview
+### Fixed
+- App bar icon is positioned right when left app bar icon is missing
+
 ## 1.1.0 - 2026-02-27
 ### Added
 - Portal around content of the App Bar Icon: `ext-add-browse-appbar-ios.app_bar_icon`

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "id": "@shopgate-project/ext-add-browse-appbar-ios",
   "components": [
     {

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "@shopgate/eslint-config"
 }

--- a/frontend/portals/AppBarIcons/index.jsx
+++ b/frontend/portals/AppBarIcons/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
 import { isIOSTheme } from '@shopgate-ps/pwa-extension-kit/env/helpers';
 import BurgerIcon from '../../components/BurgerIcon';
 
@@ -9,12 +10,22 @@ const isIOS = isIOSTheme();
  * @param {Node} children Portal children.
  * @returns{JSX}
  */
-const AppBarIcons = ({ children }) => (
-  <div style={{ display: 'flex' }}>
-    {isIOS && <BurgerIcon /> }
-    {children}
-  </div>
-);
+const AppBarIcons = ({ children }) => {
+  if (IS_PAGE_PREVIEW_ACTIVE) {
+    return null;
+  }
+
+  return (
+    <div style={{
+      display: 'flex',
+      marginLeft: 'auto',
+    }}
+    >
+      {isIOS && <BurgerIcon /> }
+      {children}
+    </div>
+  );
+};
 
 AppBarIcons.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
This pull request hides the app bar icon when app is displayed inside the CMS page preview.